### PR TITLE
New headless-chrome image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM alpine:3.15
+FROM alpine:edge
 
 RUN apk update && apk upgrade \
     && echo @edge http://nl.alpinelinux.org/alpine/edge/community >> /etc/apk/repositories \
     && echo @edge http://nl.alpinelinux.org/alpine/edge/main >> /etc/apk/repositories \
     && apk add --no-cache \
-    chromium@edge \
-    chromium-chromedriver@edge \
+    chromium \
+    chromium-chromedriver \
     xvfb \
     nss@edge \
     && rm -rf /var/lib/apt/lists/* \

--- a/init.sh
+++ b/init.sh
@@ -2,5 +2,5 @@
 
 Xvfb :99 &
 
-/usr/bin/chromedriver --whitelisted-ips 0.0.0.0
+/usr/bin/chromedriver --whitelisted-ips 0.0.0.0 --allowed-origins='*'
 


### PR DESCRIPTION
This should actually be `:alpine3.15` but the current situation is that Chrome 82 is broken on the pipeline and Chrome 93 introduced a new
security measurement that blocks cross-origin requests by giving "Host header or origin header is specified and is not whitelisted or localhost."
Chrome 95+ will include `--allowed-origins='*'` to allow developers to override this when the security concern is invalid, such as our case:
we are running on a close ephemeral environment in CodeBuild with no external access, but using docker-compose to orchestrate a distributed system.
Alpine 3.15 with chrome@edge brings a broken commit (most recent Chrome Build) while Alpine Edge with chrome@stable brings Version 96 in a working state.